### PR TITLE
#26 The repeater fields to be collapsible: add button action toggle

### DIFF
--- a/assets/views/administrator/repeater-field-actions.php
+++ b/assets/views/administrator/repeater-field-actions.php
@@ -19,5 +19,9 @@
             role="repeater-remove"
             title="<?php echo esc_attr( 'Remove', 'wpmvc-addon-administrator' ) ?>"
         ><i class="fa fa-trash" aria-hidden="true"></i></button>
+        <button type="button"
+                role="repeater-toggle-indicator"
+                title="Toggle Indicator"
+        ><i class="fa fa-caret-down" aria-hidden="true"></i></button>
     </div>
 </script>


### PR DESCRIPTION
https://github.com/10quality/wpmvc-addon-administrator/issues/26